### PR TITLE
Code for PAIRED+BC+Hient experiments

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,7 @@ This codebase contains an extensible framework for implementing various Unsuperv
 We also include experiment configurations for the main experiments in the following papers on DCD methods:
 - [Replay-Guided Adversarial Design. Jiang et al, 2021 (NeurIPS 2021)](https://arxiv.org/abs/2110.02439)
 - [Evolving Curricula with Regret-Based Environment Design. Parker-Holder et al, 2022 (ICML 2022)](https://accelagent.github.io/)
+- [Stabilizing Unsupervised Environment Design with a Learned Adversary. Mediratta et al, 2023 (CoLLAs 2023)](https://arxiv.org/abs/2308.10797)
 
 ## Citation
 The core components of this codebase, as well as the `CarRacingBezier` and `CarRacingF1` environments, were introduced in [Jiang et al, 2021](https://arxiv.org/abs/2110.02439). If you use this code to develop your own UED algorithms in academic contexts, please cite 
@@ -29,6 +30,9 @@ Additionally, if you use ACCEL or the adversarial `BipedalWalker` environments i
     
     Parker-Holder et al, "Evolving Curricula with Regret-Based Environment Design", 2022.
 ([Bibtex here](https://raw.githubusercontent.com/facebookresearch/dcd/main/docs/bibtex/accel.bib))
+
+    Mediratta et al, "Stabilizing Unsupervised Environment Design with a Learned Adversary", 2023.
+([Bibtex here](https://raw.githubusercontent.com/facebookresearch/dcd/main/docs/bibtex/collas.bib))
 
 ## Setup
 To install the necessary dependencies, run the following commands:
@@ -145,6 +149,18 @@ The [MiniGrid-based mazes](https://github.com/facebookresearch/dcd/tree/master/e
 | PLR<sup>⊥</sup> (Uniform(0-60) blocks) | `minigrid/mg_60b_uni_robust_plr.json` |
 | DR (Uniform(0-60) blocks) | `minigrid/mg_60b_uni_dr.json`|
 
+#### Experiments from [Mediratta et al, 2023](https://arxiv.org/abs/2308.10797)
+| Method        | json config  |
+| ------------- |:-------------|
+| PAIRED+HiEnt (25 blocks) | `minigrid/25_blocks/mg_25b_paired_hient.json`| 
+| PAIRED+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_hient.json`| 
+| PAIRED+BC+HiEnt (25 blocks) | `minigrid/25_blocks/mg_25b_paired_bc_hient.json`| 
+| PAIRED+BC+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_bc_hient.json`| 
+
+> NOTE: To disable `HiEnt` (for e.g. in BC experiments), set `entropy_coef = 0.0` and `adv_entropy_coef = 0.0`
+
+> NOTE: In BC experiments, set `use_kl_only_agent = True` for `UniBC` and `use_kl_only_agent = False` for `BiBC`
+
 ### 🏎 CarRacing
 
 #### `CarRacingBezier`
@@ -163,6 +179,16 @@ The [`CarRacingF1`](https://github.com/facebookresearch/dcd/tree/master/envs/box
 | REPAIRED| `car_racing/cr_repaired.json`|
 | PAIRED | `car_racing/cr_paired.json`|
 | DR | `car_racing/cr_dr.json`|
+
+#### Experiments from [Mediratta et al, 2023](https://arxiv.org/abs/2308.10797)
+| Method        | json config  |
+| ------------- |:-------------|
+| PAIRED+HiEnt | `car_racing/cr_paired_hient.json`| 
+| PAIRED+BC+HiEnt | `car_racing/cr_paired_bc_hient.json`| 
+
+> NOTE: To disable `HiEnt` (for e.g. in BC experiments), set `entropy_coef = 0.0` and `adv_entropy_coef = 0.0`
+
+> NOTE: In BC experiments, set `use_kl_only_agent = True` for `UniBC` and `use_kl_only_agent = False` for `BiBC`
 
 ### 🦿🦿 BipedalWalker
 

--- a/algos/agent.py
+++ b/algos/agent.py
@@ -9,8 +9,8 @@ class ACAgent(object):
     	self.algo = algo
     	self.storage = storage
 
-    def update(self, discard_grad=False):
-    	info = self.algo.update(self.storage, discard_grad=discard_grad)
+    def update(self, discard_grad=False, kl_dict=None):
+    	info = self.algo.update(self.storage, discard_grad=discard_grad, kl_dict=kl_dict)
     	self.storage.after_update()
 
     	return info

--- a/algos/ppo.py
+++ b/algos/ppo.py
@@ -27,6 +27,7 @@ class PPO():
                  num_mini_batch,
                  value_loss_coef,
                  entropy_coef,
+                 kl_loss_coef=0.0,
                  lr=None,
                  eps=None,
                  max_grad_norm=None,
@@ -42,6 +43,7 @@ class PPO():
 
         self.value_loss_coef = value_loss_coef
         self.entropy_coef = entropy_coef
+        self.kl_loss_coef = kl_loss_coef
 
         self.max_grad_norm = max_grad_norm
 
@@ -58,7 +60,9 @@ class PPO():
         total_norm = total_norm ** (1. / 2)
         return total_norm
 
-    def update(self, rollouts, discard_grad=False):
+    def update(self, rollouts, discard_grad=False, kl_dict=None):
+        use_kl_loss = (kl_dict is not None) and (self.kl_loss_coef > 0.0)
+        
         if rollouts.use_popart:
             value_preds = rollouts.denorm_value_preds
         else:
@@ -71,6 +75,8 @@ class PPO():
         value_loss_epoch = 0
         action_loss_epoch = 0
         dist_entropy_epoch = 0
+        if use_kl_loss:
+            kl_loss_epoch = 0
 
         if self.log_grad_norm:
             grad_norms = []
@@ -88,9 +94,18 @@ class PPO():
                 value_preds_batch, return_batch, masks_batch, old_action_log_probs_batch, \
                         adv_targ = sample
                 
-                values, action_log_probs, dist_entropy, _ = self.actor_critic.evaluate_actions(
-                    obs_batch, recurrent_hidden_states_batch, masks_batch,
-                    actions_batch)
+                if use_kl_loss:
+                    values, action_log_probs, dist_entropy, _, dist_protagonist = self.actor_critic.evaluate_actions(
+                        obs_batch, recurrent_hidden_states_batch, masks_batch,
+                        actions_batch, return_policy_logits=True)
+                    with torch.no_grad():
+                        _, _, _, _, dist_antagonist = kl_dict['antagonist_model'].evaluate_actions(
+                        obs_batch, recurrent_hidden_states_batch, masks_batch,
+                        actions_batch, return_policy_logits=True)
+                else:
+                    values, action_log_probs, dist_entropy, _ = self.actor_critic.evaluate_actions(
+                        obs_batch, recurrent_hidden_states_batch, masks_batch,
+                        actions_batch)
                     
                 ratio = torch.exp(action_log_probs -
                                   old_action_log_probs_batch)
@@ -113,9 +128,16 @@ class PPO():
                                                     value_losses_clipped).mean()
                 else:
                     value_loss = F.smooth_l1_loss(values, return_batch)
+                    
+                if use_kl_loss:
+                    kl_div = torch.distributions.kl.kl_divergence(dist_antagonist, dist_protagonist)
+                    bs = kl_div.shape[0]
+                    kl_loss = kl_div.sum() / bs
 
                 self.optimizer.zero_grad()
                 loss = (value_loss*self.value_loss_coef + action_loss - dist_entropy*self.entropy_coef)
+                if use_kl_loss:
+                    loss += (self.kl_loss_coef*kl_loss)
 
                 loss.backward()
 
@@ -132,15 +154,21 @@ class PPO():
                 value_loss_epoch += value_loss.item()
                 action_loss_epoch += action_loss.item()
                 dist_entropy_epoch += dist_entropy.item()
+                if use_kl_loss:
+                    kl_loss_epoch += kl_loss.item()
 
         num_updates = self.ppo_epoch * self.num_mini_batch
 
         value_loss_epoch /= num_updates
         action_loss_epoch /= num_updates
         dist_entropy_epoch /= num_updates
+        if use_kl_loss:
+            kl_loss_epoch /= num_updates
 
         info = {}
         if self.log_grad_norm:
             info = {'grad_norms': grad_norms}
+        if use_kl_loss:
+            info['kl_loss'] = kl_loss_epoch
 
         return value_loss_epoch, action_loss_epoch, dist_entropy_epoch, info

--- a/arguments.py
+++ b/arguments.py
@@ -322,6 +322,26 @@ parser.add_argument(
     default=0.,
     help="Number of edits to make each time a level is mutated.")
 
+# BC arguments
+parser.add_argument(
+    '--use_behavioural_cloning',
+    type=str2bool, nargs='?', const=True, default=False,
+    help='Whether to use behavioural cloning')
+parser.add_argument(
+    '--kl_update_step',
+    type=float,
+    default=1,
+    help='Number of steps after which KL loss should be used')
+parser.add_argument(
+    '--kl_loss_coef',
+    type=float,
+    default=0.0,
+    help='KL divergence loss coefficient for behavioural cloning (default: 0.1)')
+parser.add_argument(
+    '--use_kl_only_agent',
+    type=str2bool, nargs='?', const=True, default=False,
+    help='Use behavioural cloning loss in agent only. Default behaviour is bc in both')
+
 # Fine-tuning arguments.
 parser.add_argument(
     '--xpid_finetune',

--- a/docs/bibtex/collas.bib
+++ b/docs/bibtex/collas.bib
@@ -1,0 +1,7 @@
+@article{mediratta2023stabilizing,
+  title={Stabilizing Unsupervised Environment Design with a Learned Adversary},
+  author={Ishita Mediratta and Minqi Jiang and Jack Parker-Holder and Michael Dennis and Eugene Vinitsky and Tim Rocktäschel},
+  year={2023},
+  journal={Conference on Lifelong Learning Agents},
+  organization={PMLR}
+}

--- a/models/car_racing_models.py
+++ b/models/car_racing_models.py
@@ -146,7 +146,7 @@ class CarRacingNetwork(DeviceAwareModule):
 		image_embedding = self.image_embed(inputs).squeeze()
 		return self.critic(image_embedding)
 
-	def evaluate_actions(self, inputs, rnn_hxs, masks, action):
+	def evaluate_actions(self, inputs, rnn_hxs, masks, action, return_policy_logits=False):
 		image_embedding = self.image_embed(inputs).squeeze()
 
 		actor_fc_embed = self.actor_fc(image_embedding)
@@ -161,6 +161,9 @@ class CarRacingNetwork(DeviceAwareModule):
 		dist_entropy = dist.entropy().mean()
 
 		value = self.critic(image_embedding)
+
+		if return_policy_logits:
+			return value, action_log_probs, dist_entropy, rnn_hxs, dist
 
 		return value, action_log_probs, dist_entropy, rnn_hxs
 

--- a/models/multigrid_models.py
+++ b/models/multigrid_models.py
@@ -174,7 +174,7 @@ class MultigridNetwork(DeviceAwareModule):
         core_features, rnn_hxs = self._forward_base(inputs, rnn_hxs, masks)
         return self.critic(core_features)
 
-    def evaluate_actions(self, inputs, rnn_hxs, masks, action):
+    def evaluate_actions(self, inputs, rnn_hxs, masks, action, return_policy_logits=False):
         core_features, rnn_hxs = self._forward_base(inputs, rnn_hxs, masks)
 
         dist = self.actor(core_features)
@@ -183,4 +183,7 @@ class MultigridNetwork(DeviceAwareModule):
         action_log_probs = dist.log_probs(action)
         dist_entropy = dist.entropy().mean()
 
+        if return_policy_logits:
+            return value, action_log_probs, dist_entropy, rnn_hxs, dist
+        
         return value, action_log_probs, dist_entropy, rnn_hxs

--- a/models/walker_models.py
+++ b/models/walker_models.py
@@ -157,12 +157,15 @@ class BipedalWalkerStudentPolicy(DeviceAwareModule):
         value, _, _ = self.base(inputs, rnn_hxs, masks)
         return value
 
-    def evaluate_actions(self, inputs, rnn_hxs, masks, action):
+    def evaluate_actions(self, inputs, rnn_hxs, masks, action, return_policy_logits=False):
         value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
         dist = self.dist(actor_features)
 
         action_log_probs = dist.log_probs(action)
         dist_entropy = dist.entropy().mean()
+
+        if return_policy_logits:
+            return value, action_log_probs, dist_entropy, rnn_hxs, dist
 
         return value, action_log_probs, dist_entropy, rnn_hxs
 

--- a/train_scripts/grid_configs/car_racing/cr_paired_bc_hient.json
+++ b/train_scripts/grid_configs/car_racing/cr_paired_bc_hient.json
@@ -1,0 +1,67 @@
+{
+	"grid" :{
+		"env_name":[
+			"CarRacing-Bezier-Adversarial-v0"
+		],
+
+	  "ued_algo": ["paired"],
+	  "num_processes": [16],
+	  "num_env_steps": [5500000],
+	  "num_steps": [125],
+	  "ppo_epoch": [8],
+	  "num_mini_batch":[4],
+	  "grayscale": [false],
+	  "crop_frame": [false],
+	  "num_action_repeat": [8],
+	  "frame_stack": [4],
+	  "normalize_returns": [true],
+	  "use_popart": [false],
+	  "handle_timelimits": [true],
+
+	  "recurrent_agent": [false],
+	  "recurrent_adversary_env": [false],
+	  "recurrent_hidden_size": [1],
+
+	  "lr": [3e-4],
+	  "max_grad_norm": [0.5],
+	  "gamma": [0.99],
+	  "gae_lambda": [0.9],
+	  "value_loss_coef": [0.5],
+	  "entropy_coef": [0.005],
+	  "clip_value_loss": [false],
+	  "clip_param": [0.2],
+	  "reward_shaping": [true],
+	  "adv_entropy_coef": [0.05],
+	  "use_categorical_adv": [true],
+	  "use_skip": [false],
+	  "choose_start_pos": [false],
+	  "sparse_rewards":[false],
+
+	  "use_behavioural_cloning": [true],
+	  "kl_loss_coef": [0.5],
+	  "kl_update_step": [10],
+	  "use_kl_only_agent": [false, true],
+
+		"adv_max_grad_norm": [0.5],
+		"adv_ppo_epoch": [8],
+		"adv_num_mini_batch": [4],
+		"adv_normalize_returns": [true],
+		"adv_use_popart": [false],
+
+	  "test_env_names": ["CarRacing-Vanilla-v0,CarRacingF1-Italy-v0,CarRacingF1-Singapore-v0,CarRacingF1-Germany-v0"],
+
+	  "log_dir": ["~/logs/dcd"],
+	  "log_interval": [10],
+	  "test_interval": [100],
+	  "test_num_episodes":[5],
+	  "test_num_processes":[5],
+	  "screenshot_interval":[200],
+	  "log_plr_buffer_stats": [true],
+	  "log_replay_complexity": [true],
+	  "checkpoint":[true],
+	  "archive_interval":[1250],
+
+    "log_action_complexity": [false],
+    "log_grad_norm": [true]
+	}
+}

--- a/train_scripts/grid_configs/car_racing/cr_paired_hient.json
+++ b/train_scripts/grid_configs/car_racing/cr_paired_hient.json
@@ -1,0 +1,62 @@
+{
+	"grid" :{
+		"env_name":[
+			"CarRacing-Bezier-Adversarial-v0"
+		],
+
+	  "ued_algo": ["paired"],
+	  "num_processes": [16],
+	  "num_env_steps": [5500000],
+	  "num_steps": [125],
+	  "ppo_epoch": [8],
+	  "num_mini_batch":[4],
+	  "grayscale": [false],
+	  "crop_frame": [false],
+	  "num_action_repeat": [8],
+	  "frame_stack": [4],
+	  "normalize_returns": [true],
+	  "use_popart": [false],
+	  "handle_timelimits": [true],
+
+	  "recurrent_agent": [false],
+	  "recurrent_adversary_env": [false],
+	  "recurrent_hidden_size": [1],
+
+	  "lr": [3e-4],
+	  "max_grad_norm": [0.5],
+	  "gamma": [0.99],
+	  "gae_lambda": [0.9],
+	  "value_loss_coef": [0.5],
+	  "entropy_coef": [0.05],
+	  "clip_value_loss": [false],
+	  "clip_param": [0.2],
+	  "reward_shaping": [true],
+	  "adv_entropy_coef": [0.1],
+	  "use_categorical_adv": [true],
+	  "use_skip": [false],
+	  "choose_start_pos": [false],
+	  "sparse_rewards":[false],
+
+		"adv_max_grad_norm": [0.5],
+		"adv_ppo_epoch": [8],
+		"adv_num_mini_batch": [4],
+		"adv_normalize_returns": [true],
+		"adv_use_popart": [false],
+
+	  "test_env_names": ["CarRacing-Vanilla-v0,CarRacingF1-Italy-v0,CarRacingF1-Singapore-v0,CarRacingF1-Germany-v0"],
+
+	  "log_dir": ["~/logs/dcd"],
+	  "log_interval": [10],
+	  "test_interval": [100],
+	  "test_num_episodes":[5],
+	  "test_num_processes":[5],
+	  "screenshot_interval":[200],
+	  "log_plr_buffer_stats": [true],
+	  "log_replay_complexity": [true],
+	  "checkpoint":[true],
+	  "archive_interval":[1250],
+
+    "log_action_complexity": [false],
+    "log_grad_norm": [true]
+	}
+}

--- a/train_scripts/grid_configs/minigrid/25_blocks/mg_25b_paired_bc_hient.json
+++ b/train_scripts/grid_configs/minigrid/25_blocks/mg_25b_paired_bc_hient.json
@@ -1,0 +1,40 @@
+{
+    "grid" :{
+      "env_name":[
+          "MultiGrid-GoalLastFewerBlocksAdversarial-v0"
+      ],
+  
+      "ued_algo": ["paired"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+  
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.005],
+      "adv_entropy_coef": [0.05],
+  
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [true],
+      "recurrent_hidden_size": [256],
+  
+      "use_behavioural_cloning": [true],
+      "kl_loss_coef": [0.1],
+      "kl_update_step": [25],
+      "use_kl_only_agent": [false, true],
+  
+      "log_dir": ["~/logs/dcd"],
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "archive_interval": [30518],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false], 
+  
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/grid_configs/minigrid/25_blocks/mg_25b_paired_hient.json
+++ b/train_scripts/grid_configs/minigrid/25_blocks/mg_25b_paired_hient.json
@@ -1,0 +1,35 @@
+{
+    "grid" :{
+      "env_name":[
+          "MultiGrid-GoalLastFewerBlocksAdversarial-v0"
+      ],
+  
+      "ued_algo": ["paired"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+  
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.005],
+      "adv_entropy_coef": [0.01],
+  
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [true],
+      "recurrent_hidden_size": [256],
+  
+      "log_dir": ["~/logs/dcd"],
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "archive_interval": [30518],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false], 
+  
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired.json
+++ b/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired.json
@@ -1,0 +1,43 @@
+{
+    "grid" :{
+      "env_name":[
+          "MultiGrid-GoalLastVariableBlocksAdversarialEnv-v0"
+      ],
+
+      "ued_algo": ["paired"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+
+      "checkpoint_basis":["student_grad_updates"],
+      "archive_interval": [5000],
+
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.0],
+      "adv_entropy_coef": [0.0],
+
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [true],
+      "recurrent_hidden_size": [256],
+
+      "use_editor": [false],
+
+      "test_env_names": ["MultiGrid-SixteenRooms-v0,MultiGrid-Maze-v0,MultiGrid-Labyrinth-v0"],
+
+      "log_dir": ["~/logs/accel"],
+
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false], 
+      "screenshot_interval": [1000],
+
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_bc_hient.json
+++ b/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_bc_hient.json
@@ -1,0 +1,47 @@
+{
+    "grid" :{
+      "env_name":[
+          "MultiGrid-GoalLastVariableBlocksAdversarialEnv-v0"
+      ],
+
+      "ued_algo": ["paired"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+
+      "checkpoint_basis":["student_grad_updates"],
+      "archive_interval": [5000],
+
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.005],
+      "adv_entropy_coef": [0.005],
+
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [true],
+      "recurrent_hidden_size": [256],
+
+      "use_behavioural_cloning": [true],
+      "kl_loss_coef": [0.01],
+      "kl_update_step": [5],
+      "use_kl_only_agent": [false, true],
+
+      "use_editor": [false],
+
+      "test_env_names": ["MultiGrid-SixteenRooms-v0,MultiGrid-Maze-v0,MultiGrid-Labyrinth-v0"],
+
+      "log_dir": ["~/logs/accel"],
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false], 
+      "screenshot_interval": [1000],
+
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_hient.json
+++ b/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_hient.json
@@ -1,0 +1,43 @@
+{
+    "grid" :{
+      "env_name":[
+          "MultiGrid-GoalLastVariableBlocksAdversarialEnv-v0"
+      ],
+
+      "ued_algo": ["paired"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+
+      "checkpoint_basis":["student_grad_updates"],
+      "archive_interval": [5000],
+
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.005],
+      "adv_entropy_coef": [0.05],
+
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [true],
+      "recurrent_hidden_size": [256],
+
+      "use_editor": [false],
+      
+      "test_env_names": ["MultiGrid-SixteenRooms-v0,MultiGrid-Maze-v0,MultiGrid-Labyrinth-v0"],
+
+      "log_dir": ["~/logs/accel"],
+
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false], 
+      "screenshot_interval": [1000],
+
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/make_cmd.py
+++ b/train_scripts/make_cmd.py
@@ -147,6 +147,11 @@ def xpid_from_params(p, prefix=''):
         rnn_prefix = f'-{rnn_arch}{rnn_hidden}{rnn_agent}{rnn_env}'
 
     ppo_prefix = f"-lr{p['lr']}-epoch{p['ppo_epoch']}-mb{p['num_mini_batch']}-v{p['value_loss_coef']}-gc{p['max_grad_norm']}"
+    
+    if p['use_behavioural_cloning']:
+        ppo_prefix = f"{ppo_prefix}-kl{p['kl_loss_coef']}-klstep{p['kl_update_step']}"
+        if p['use_kl_only_agent']:
+            ppo_prefix = f"{ppo_prefix}-uni"
 
     if p['env_name'].startswith('CarRacing'):
         clip_v_prefix = ''
@@ -236,6 +241,12 @@ if __name__ == '__main__':
         'level_editor_method': 'random',
         'num_edits': 0,
         'base_levels': 'batch',
+        
+        # Behavioural Cloning params
+        'use_behavioural_cloning': False,
+        'kl_loss_coef': 0.0,
+        'kl_update_step': 1,
+        'use_kl_only_agent': False,
 
         # Logging params
         'log_interval': 25,

--- a/util/make_agent.py
+++ b/util/make_agent.py
@@ -216,6 +216,7 @@ def make_agent(name, env, args, device='cpu'):
             num_mini_batch=num_mini_batch,
             value_loss_coef=args.value_loss_coef,
             entropy_coef=entropy_coef,
+            kl_loss_coef=args.kl_loss_coef,
             lr=args.lr,
             eps=args.eps,
             max_grad_norm=max_grad_norm,


### PR DESCRIPTION
This PR adds support for BC & Hi Entropy experiments in PAIRED for all three environment types. After implementing the changes, we are still able to repro the underlying ACCEL's rollouts for 1-2 episodes.