### PR TITLE
Add code for PAIRED+Evo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,6 +14,7 @@ This codebase contains an extensible framework for implementing various Unsuperv
 - [ALP-GMM](https://arxiv.org/abs/1910.07224)
 - [Minimax adversarial training](https://arxiv.org/abs/2012.02096)
 - [Domain randomization (DR)](https://arxiv.org/abs/1703.06907)
+- [PAIRED+HiEnt+BC+Evo](https://arxiv.org/abs/2308.10797)
 
 We also include experiment configurations for the main experiments in the following papers on DCD methods:
 - [Replay-Guided Adversarial Design. Jiang et al, 2021 (NeurIPS 2021)](https://arxiv.org/abs/2110.02439)
@@ -30,6 +31,8 @@ Additionally, if you use ACCEL or the adversarial `BipedalWalker` environments i
     
     Parker-Holder et al, "Evolving Curricula with Regret-Based Environment Design", 2022.
 ([Bibtex here](https://raw.githubusercontent.com/facebookresearch/dcd/main/docs/bibtex/accel.bib))
+
+Finally, if you use PAIRED with High Entropy (HiEnt) and/or Behavioral Cloning (BC) and/or Evo method, please cite
 
     Mediratta et al, "Stabilizing Unsupervised Environment Design with a Learned Adversary", 2023.
 ([Bibtex here](https://raw.githubusercontent.com/facebookresearch/dcd/main/docs/bibtex/collas.bib))
@@ -155,7 +158,8 @@ The [MiniGrid-based mazes](https://github.com/facebookresearch/dcd/tree/master/e
 | PAIRED+HiEnt (25 blocks) | `minigrid/25_blocks/mg_25b_paired_hient.json`| 
 | PAIRED+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_hient.json`| 
 | PAIRED+BC+HiEnt (25 blocks) | `minigrid/25_blocks/mg_25b_paired_bc_hient.json`| 
-| PAIRED+BC+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_bc_hient.json`| 
+| PAIRED+BC+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_bc_hient.json`|
+| PAIRED+Evo+BC+HiEnt (Uniform(0-60) blocks) | `minigrid/60_blocks_uniform/mg_60b_uni_paired_evo_bc_hient.json`|  
 
 > NOTE: To disable `HiEnt` (for e.g. in BC experiments), set `entropy_coef = 0.0` and `adv_entropy_coef = 0.0`
 
@@ -204,6 +208,7 @@ The [BipedalWalker environment](https://github.com/facebookresearch/dcd/tree/mas
 | PAIRED | `bipedal/bipedal_paired.json`|
 | Minimax | `bipedal/bipedal_minimax.json`|
 | DR | `bipedal/bipedal_dr.json`|
+| PAIRED+Evo+BC+HiEnt | `bipedal/bipedal_paired_evo_bc_hient.json`|
 
 ![Example ACCEL BipedalWalker agent on challenging terrain](/docs/images/accel_bipedal_demo.gif)
 
@@ -218,6 +223,8 @@ The [BipedalWalker environment](https://github.com/facebookresearch/dcd/tree/mas
 | PAIRED  |✅ |✅ |✅ | 
 | Minimax  |✅ |✅ |✅ | 
 | DR  |✅ |✅ |✅ | 
+| PAIRED+BC  |✅ |✅ |✅ | 
+| PAIRED+Evo  |✅ |❌ |✅ | 
 
 
 ## 🏗 Integrating a new environment

--- a/algos/ppo.py
+++ b/algos/ppo.py
@@ -61,7 +61,7 @@ class PPO():
         return total_norm
 
     def update(self, rollouts, discard_grad=False, kl_dict=None):
-        use_kl_loss = (kl_dict is not None) and (self.kl_loss_coef > 0.0)
+        use_kl_loss = (kl_dict is not None) and (self.kl_loss_coef > 0.0) and (discard_grad is False)
         
         if rollouts.use_popart:
             value_preds = rollouts.denorm_value_preds

--- a/arguments.py
+++ b/arguments.py
@@ -314,13 +314,26 @@ parser.add_argument(
     "--base_levels",
     type=str,
     default='batch',
-    choices=['batch', 'easy'],
+    choices=['batch', 'easy', 'hard'],
     help="What kind of replayed level under PLR do we edit?")
 parser.add_argument(
     "--num_edits",
     type=int,
     default=0.,
     help="Number of edits to make each time a level is mutated.")
+parser.add_argument(
+    "--use_accel_paired",
+    type=str2bool, nargs='?', const=True, default=False,
+    help='Whether to use paired regret estimate for level editor.')
+parser.add_argument(
+    "--accel_paired_score_function",
+    type=str, default="paired", choices=["paired", "flex_paired"],
+    help="Type of regret estimate for level editor"
+)
+parser.add_argument(
+    "--use_lstm",
+    type=str2bool, nargs='?', const=True, default=False,
+    help='Whether to use LSTM architecture for BipedalWalker models.')
 
 # BC arguments
 parser.add_argument(

--- a/envs/runners/adversarial_runner.py
+++ b/envs/runners/adversarial_runner.py
@@ -601,7 +601,6 @@ class AdversarialRunner(object):
                                 set_obs_at_index(obs, obs_i, i)
                                 next_level_seeds[i] = level_seed
                                 rollout_info['solved_idx'][i] = True
-                                # self.current_level_seeds[i] = level_seed
 
                         # If using ALP-GMM, sample next level
                         if self.is_alp_gmm:
@@ -947,7 +946,7 @@ class AdversarialRunner(object):
                 else:
                     # take top 1
                     if self.use_accel_paired:
-                        easy = np.argmin((regret_score.detach().cpu().numpy()).flatten())
+                        easy = np.argmax((regret_score.detach().cpu().numpy()).flatten())
                     else:
                         easy = np.argmax((agent_info['mean_return'].detach().cpu().numpy() - agent_info['batched_value_loss'].detach().cpu().numpy()).flatten())
                     fixed_seeds = [env_info[easy]] * args.num_processes

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,3 +8,4 @@ from .multigrid_models import MultigridNetwork
 from .multigrid_global_critic_models import MultigridGlobalCriticNetwork
 from .car_racing_models import CarRacingNetwork, CarRacingBezierAdversaryEnvNetwork
 from .walker_models import BipedalWalkerStudentPolicy, BipedalWalkerAdversaryPolicy
+from .recurrent_walker_models import BipedalWalkerRecurrentStudentPolicy, BipedalWalkerRecurrentAdversaryPolicy

--- a/models/recurrent_walker_models.py
+++ b/models/recurrent_walker_models.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2017 Ilya Kostrikov
+# 
+# Licensed under the MIT License;
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/licenses/MIT
+#
+# This file is a modified version code found in
+# https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail/
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.distributions import Beta
+from gym.spaces import MultiDiscrete
+from collections import namedtuple
+
+from .common import *
+from torch.distributions.normal import Normal
+from .popart import PopArt
+
+
+# Necessary for my KFAC implementation.
+class AddBias(nn.Module):
+    def __init__(self, bias):
+        super(AddBias, self).__init__()
+        self._bias = nn.Parameter(bias.unsqueeze(1))
+
+    def forward(self, x):
+        if x.dim() == 2:
+            bias = self._bias.t().view(1, -1)
+        else:
+            bias = self._bias.t().view(1, -1, 1, 1)
+
+        return x + bias
+
+# Normal
+class FixedNormal(torch.distributions.Normal):
+    def log_probs(self, actions):
+        return super().log_prob(actions).sum(-1, keepdim=True)
+
+    def entropy(self):
+        return super().entropy().sum(-1)
+
+    def mode(self):
+        return self.mean
+
+class DiagGaussian(DeviceAwareModule):
+    def __init__(self, num_inputs, num_outputs):
+        super(DiagGaussian, self).__init__()
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0))
+
+        self.fc_mean = init_(nn.Linear(num_inputs, num_outputs))
+        self.logstd = AddBias(torch.zeros(num_outputs))
+
+    def forward(self, x):
+        action_mean = self.fc_mean(x)
+
+        #  An ugly hack for my KFAC implementation.
+        zeros = torch.zeros(action_mean.size())
+        if x.is_cuda:
+            zeros = zeros.cuda()
+
+        action_logstd = self.logstd(zeros)
+        return FixedNormal(action_mean, action_logstd.exp())
+
+class FixedCategorical(torch.distributions.Categorical):
+    def sample(self):
+        return super().sample().unsqueeze(-1)
+
+    def log_probs(self, actions):
+        return (
+            super()
+            .log_prob(actions.squeeze(-1))
+            .view(actions.size(0), -1)
+            .sum(-1)
+            .unsqueeze(-1)
+        )
+
+    def mode(self):
+        return self.probs.argmax(dim=-1, keepdim=True)
+
+class Categorical(nn.Module):
+    def __init__(self, num_inputs, num_outputs):
+        super(Categorical, self).__init__()
+
+        init_ = lambda m: init(
+            m,
+            nn.init.orthogonal_,
+            lambda x: nn.init.constant_(x, 0),
+            gain=0.01)
+
+        self.linear = init_(nn.Linear(num_inputs, num_outputs))
+
+    def forward(self, x):
+        x = self.linear(x)
+        return FixedCategorical(logits=x)
+
+def init(module, weight_init, bias_init, gain=1):
+    weight_init(module.weight.data, gain=gain)
+    bias_init(module.bias.data)
+    return module
+
+## Policy from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail/blob/master/a2c_ppo_acktr/model.py
+
+class Flatten(nn.Module):
+    def forward(self, x):
+        return x.view(x.size(0), -1)
+
+class BipedalWalkerRecurrentStudentPolicy(DeviceAwareModule):
+    def __init__(self, obs_shape, action_space, recurrent=False, recurrent_hidden_size=256, base_kwargs=None):
+        super(BipedalWalkerRecurrentStudentPolicy, self).__init__()
+
+        if base_kwargs is None:
+            base_kwargs = {}
+
+        self.base = MLPBase(obs_shape[0], recurrent=recurrent, recurrent_hidden_size=recurrent_hidden_size, **base_kwargs)
+
+        num_outputs = action_space.shape[0]
+        self.dist = DiagGaussian(self.base.output_size, num_outputs)
+
+        if recurrent:
+            RNN = namedtuple("RNN", 'arch')
+            self.rnn = RNN('lstm')
+
+    @property
+    def is_recurrent(self):
+        return self.base.is_recurrent
+
+    @property
+    def recurrent_hidden_state_size(self):
+        """Size of rnn_hx."""
+        return self.base.recurrent_hidden_state_size
+
+    def forward(self, inputs):
+        value, action, action_log_probs, rnn_hxs = self.act(inputs, rnn_hxs=None, masks=None, deterministic=False)
+        return action
+
+    def act(self, inputs, rnn_hxs, masks, deterministic=False):
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        dist = self.dist(actor_features)
+
+        if deterministic:
+            action = dist.mode()
+        else:
+            action = dist.sample()
+
+        action_log_probs = dist.log_probs(action)
+        dist_entropy = dist.entropy().mean()
+
+        return value, action, action_log_probs, rnn_hxs
+
+    def get_value(self, inputs, rnn_hxs, masks):
+        value, _, _ = self.base(inputs, rnn_hxs, masks)
+        return value
+
+    def evaluate_actions(self, inputs, rnn_hxs, masks, action, return_policy_logits=False):
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        dist = self.dist(actor_features)
+        action_log_probs = dist.log_probs(action)
+        
+        dist_entropy = dist.entropy().mean()
+
+        if return_policy_logits:
+            return value, action_log_probs, dist_entropy, rnn_hxs, dist  
+
+        return value, action_log_probs, dist_entropy, rnn_hxs
+
+
+class BipedalWalkerRecurrentAdversaryPolicy(DeviceAwareModule):
+    def __init__(self, observation_space, action_space, editor=False, generate_entropies=False, random=False, recurrent=False, recurrent_hidden_size=256,base_kwargs=None):
+        super(BipedalWalkerRecurrentAdversaryPolicy, self).__init__()
+
+        if base_kwargs is None:
+            base_kwargs = {}
+
+        self.random = random
+
+        self.design_dim = observation_space['image'].shape[0]
+        self.random_z_dim = observation_space['random_z'].shape[0]
+
+        obs_dim = self.design_dim + self.random_z_dim  + 1
+
+        self.base = MLPBase(obs_dim, recurrent=recurrent, recurrent_hidden_size=recurrent_hidden_size, **base_kwargs)
+
+        self.editor = editor
+
+        self.action_dim = action_space.shape[0]
+        
+        if self.editor:
+            self.dist = [Categorical(self.base.output_size, x) for x in action_space.nvec]
+            self.action_space = action_space
+        else:
+            self.dist = DiagGaussian(self.base.output_size, self.action_dim)
+
+    @property
+    def is_recurrent(self):
+        return self.base.is_recurrent
+
+    @property
+    def recurrent_hidden_state_size(self):
+        """Size of rnn_hx."""
+        return self.base.recurrent_hidden_state_size
+
+    def preprocess(self, inputs):
+        obs = torch.cat([inputs['image'], inputs['random_z'], inputs['time_step']], axis=1)
+        return obs
+
+    def act(self, inputs, rnn_hxs, masks, deterministic=False):
+
+        inputs = self.preprocess(inputs)
+
+        if self.random:
+            if self.editor:
+                B = inputs.shape[0]
+                action = torch.zeros((B, 2), dtype=torch.int64, device=self.device)
+                action_log_dist = torch.ones(B, self.action_space.nvec[0] + self.action_space.nvec[1], device=self.device)
+                for b in range(B):
+                    action[b] = torch.tensor(self.action_space.sample()).to(self.device)
+            else:
+                action = torch.tensor(np.random.uniform(-1,1, inputs.shape[0]), device=self.device).reshape(-1,1)
+                action_log_dist = torch.ones(inputs.shape[0], self.action_dim, device=self.device)
+            values = torch.zeros(inputs.shape[0], 1, device=self.device)
+            return values, action, action_log_dist, rnn_hxs
+
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        
+        if self.editor:
+            dist = [fwd(actor_features) for fwd in self.dist]
+        else:
+            dist = self.dist(actor_features)
+
+        if deterministic:
+            action = dist.mode()
+        else:
+            action = dist.sample()
+
+        action = F.tanh(action)
+
+        action_log_probs = dist.log_probs(action)
+        dist_entropy = dist.entropy().mean()
+
+        return value, action, action_log_probs, rnn_hxs
+
+    def get_value(self, inputs, rnn_hxs, masks):
+        inputs = self.preprocess(inputs)
+        value, _, _ = self.base(inputs, rnn_hxs, masks)
+        return value
+
+    def evaluate_actions(self, inputs, rnn_hxs, masks, action):
+        inputs = self.preprocess(inputs)
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        dist = self.dist(actor_features)
+        action_log_probs = dist.log_probs(action)
+        
+        dist_entropy = dist.entropy().mean()
+
+        return value, action_log_probs, dist_entropy, rnn_hxs
+
+
+class NNBase(nn.Module):
+    def __init__(self, recurrent, input_size, hidden_size=128, recurrent_hidden_size=256, arch='lstm'):
+        super(NNBase, self).__init__()
+
+        self._hidden_size = hidden_size
+        self._recurrent_hidden_size  = recurrent_hidden_size
+        self._recurrent = recurrent
+
+        self.arch = arch
+        self.is_lstm = arch == 'lstm'
+
+        if recurrent:
+            if arch == 'gru':
+                self.rnn = nn.GRU(input_size, self._recurrent_hidden_size)
+            elif arch == 'lstm':
+                self.rnn = nn.LSTM(input_size, self._recurrent_hidden_size)
+            else:
+                raise ValueError(f'Unsupported RNN architecture {arch}.')
+            for name, param in self.rnn.named_parameters():
+                if 'bias' in name:
+                    nn.init.constant_(param, 0)
+                elif 'weight' in name:
+                    nn.init.orthogonal_(param)
+
+    @property
+    def is_recurrent(self):
+        return self._recurrent
+
+    @property
+    def recurrent_hidden_state_size(self):
+        if self._recurrent:
+            return self._recurrent_hidden_size
+        return 1
+
+    @property
+    def recurrent_output_size(self):
+        return self._recurrent_hidden_size
+
+    @property
+    def output_size(self):
+        return self._hidden_size
+
+    def _forward_gru(self, x, hxs, masks):
+
+        if self.is_lstm:
+            # Since nn.LSTM defaults to all zero states if passed None state
+            hidden_batch_size = x.size(0) if hxs is None else hxs[0].size(0)
+        else:
+            hidden_batch_size = hxs.size(0)
+
+        if x.size(0) == hidden_batch_size:
+            masked_hxs = tuple((h*masks).unsqueeze(0) for h in hxs) if self.is_lstm \
+                else (hxs*masks).unsqueeze(0)
+
+            x, hxs = self.rnn(x.unsqueeze(0), masked_hxs)
+            x = x.squeeze(0)
+
+            hxs = tuple(h.squeeze(0) for h in hxs) if self.is_lstm else hxs.squeeze(0)
+        else:
+            # x is a (T, N, -1) tensor that has been flatten to (T * N, -1)
+            N = hxs[0].size(0) if self.is_lstm else hxs.size(0) 
+            T = int(x.size(0) / N)
+
+            # unflatten
+            x = x.view(T, N, x.size(1))
+
+            # Same deal with masks
+            masks = masks.view(T, N)
+
+            # Let's figure out which steps in the sequence have a zero for any agent
+            # We will always assume t=0 has a zero in it as that makes the logic cleaner
+            has_zeros = ((masks[1:] == 0.0) \
+                            .any(dim=-1)
+                            .nonzero()
+                            .squeeze()
+                            .cpu())
+
+            # +1 to correct the masks[1:]
+            if has_zeros.dim() == 0:
+                # Deal with scalar
+                has_zeros = [has_zeros.item() + 1]
+            else:
+                has_zeros = (has_zeros + 1).numpy().tolist()
+
+            # add t=0 and t=T to the list
+            has_zeros = [0] + has_zeros + [T]
+
+            hxs = (h.unsqueeze(0) for h in hxs) if self.is_lstm else hxs.unsqueeze(0)
+            outputs = []
+            for i in range(len(has_zeros) - 1):
+                # We can now process steps that don't have any zeros in masks together!
+                # This is much faster
+                start_idx = has_zeros[i]
+                end_idx = has_zeros[i + 1]
+
+                masked_hxs = tuple(h*masks[start_idx].view(1, -1, 1) for h in hxs) if self.is_lstm \
+                    else hxs*masks[start_idx].view(1, -1, 1)
+                rnn_scores, hxs = self.rnn(
+                    x[start_idx:end_idx],
+                    masked_hxs)
+
+                outputs.append(rnn_scores)
+
+            # assert len(outputs) == T
+            # x is a (T, N, -1) tensor
+            x = torch.cat(outputs, dim=0)
+            # flatten
+            x = x.view(T * N, -1)
+            hxs = tuple(h.squeeze(0) for h in hxs) if self.is_lstm else hxs.squeeze(0)
+
+        return x, hxs
+
+class MLPBase(NNBase):
+    def __init__(self, num_inputs, recurrent=False, hidden_size=64, recurrent_hidden_size=256):
+        super(MLPBase, self).__init__(recurrent, num_inputs, hidden_size, recurrent_hidden_size)
+
+        if recurrent:
+            num_inputs = recurrent_hidden_size
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0), np.sqrt(2))
+
+        self.actor = nn.Sequential(
+            init_(nn.Linear(num_inputs, hidden_size)), nn.Tanh(),
+            init_(nn.Linear(hidden_size, hidden_size)), nn.Tanh())
+
+        self.critic = nn.Sequential(
+            init_(nn.Linear(num_inputs, hidden_size)), nn.Tanh(),
+            init_(nn.Linear(hidden_size, hidden_size)), nn.Tanh())
+
+        self.critic_linear = init_(nn.Linear(hidden_size, 1))
+
+        self.train()
+
+    def forward(self, inputs, rnn_hxs, masks):
+        x = inputs
+
+        if self.is_recurrent:
+            x, rnn_hxs = self._forward_gru(x, rnn_hxs, masks)
+
+        hidden_critic = self.critic(x)
+        hidden_actor = self.actor(x)
+
+        return self.critic_linear(hidden_critic), hidden_actor, rnn_hxs
+

--- a/train.py
+++ b/train.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     agent = make_agent(name='agent', env=venv, args=args, device=device)
     adversary_agent, adversary_env = None, None
-    if is_paired:
+    if is_paired or args.use_accel_paired:
         adversary_agent = make_agent(name='adversary_agent', env=venv, args=args, device=device)
 
     if is_training_env:
@@ -176,6 +176,13 @@ if __name__ == '__main__':
             if evaluator is not None and (j % args.test_interval == 0 or j == num_updates - 1):
                 test_stats = evaluator.evaluate(train_runner.agents['agent'])
                 stats.update(test_stats)
+                if args.use_accel_paired:
+                    adv_test_stats = evaluator.evaluate(train_runner.agents['adversary_agent'])
+                    curr_keys = list(adv_test_stats.keys())
+                    for curr_key in curr_keys:
+                        adv_test_stats[f"advagent_{curr_key}"] = adv_test_stats[curr_key]
+                        adv_test_stats.pop(curr_key, None)
+                    stats.update(adv_test_stats)
             else:
                 stats.update({k:None for k in evaluator.get_stats_keys()})
 

--- a/train_scripts/grid_configs/bipedal/bipedal_paired_evo_bc_hient.json
+++ b/train_scripts/grid_configs/bipedal/bipedal_paired_evo_bc_hient.json
@@ -1,0 +1,75 @@
+{
+	"grid" :{
+		"env_name":[
+			"BipedalWalker-Adversarial-Easy-v0"
+		],
+
+	  "ued_algo": ["domain_randomization"],
+	  "num_processes": [16],
+	  "num_env_steps": [2000000000],
+	  "num_steps": [2048],
+	  "ppo_epoch": [5],
+	  "num_mini_batch":[32],
+	  "normalize_returns": [true],
+	  "use_accel_paired": [true],
+	  "accel_paired_score_function": ["paired"],
+
+	  "checkpoint_basis":["student_grad_updates"],
+	  "archive_interval": [5000],
+
+	  "recurrent_agent": [false],
+	  "recurrent_adversary_env": [false],
+	  "recurrent_hidden_size": [1],
+
+	  "lr": [3e-4],
+	  "max_grad_norm": [0.5],
+	  "gamma": [0.99],
+	  "gae_lambda": [0.9],
+	  "value_loss_coef": [0.5],
+	  "entropy_coef": [0.001],
+	  "adv_entropy_coef": [0.01],
+	  "clip_value_loss": [false],
+	  "clip_param": [0.2],
+	  "reward_shaping": [true],
+	  "use_categorical_adv": [true],
+	  "use_skip": [false],
+	  "choose_start_pos": [false],
+	  "sparse_rewards":[false],
+	  "handle_timelimits": [true],
+
+    "use_plr": [true],
+    "level_replay_strategy":["positive_value_loss"],
+    "level_replay_score_transform":["rank"],
+    "level_replay_prob": [0.9],
+    "level_replay_rho":[0.5],
+    "level_replay_seed_buffer_size":[1000],
+	  "staleness_coef": [0.5],
+		"no_exploratory_grad_updates": [true],
+
+	  "use_editor": [true],
+	  "level_editor_prob": [1.0],
+	  "level_editor_method": ["random"],
+	  "num_edits": [3],
+	  "base_levels": ["easy"],
+
+      "use_behavioural_cloning": [true],
+        "kl_loss_coef": [0.1],
+        "kl_update_step": [10],
+		"use_kl_only_agent": [false, true],
+
+	  "test_env_names": ["BipedalWalker-v3,BipedalWalkerHardcore-v3,BipedalWalker-Med-Stairs-v0,BipedalWalker-Med-PitGap-v0,BipedalWalker-Med-StumpHeight-v0,BipedalWalker-Med-Roughness-v0"],
+
+	  "log_dir": ["~/logs/accel"],
+	  "log_interval": [10],
+	  "test_interval": [100],
+	  "test_num_episodes":[10],
+	  "test_num_processes":[2],
+	  "screenshot_interval":[200],
+	  "log_plr_buffer_stats": [true],
+	  "log_replay_complexity": [true],
+	  "checkpoint":[true],
+
+    "log_action_complexity": [false],
+    "log_grad_norm": [true]
+	}
+}

--- a/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_evo_bc_hient.json
+++ b/train_scripts/grid_configs/minigrid/60_blocks_uniform/mg_60b_uni_paired_evo_bc_hient.json
@@ -1,0 +1,62 @@
+{
+    "grid" :{
+      "env_name":[
+        "MultiGrid-GoalLastEmptyAdversarialEnv-Edit-v0"
+      ],
+  
+      "ued_algo": ["domain_randomization"],
+      "num_processes": [32],
+      "num_env_steps": [250000000],
+      "num_steps": [256],
+      "ppo_epoch": [5],
+      "num_mini_batch":[1],
+      "handle_timelimits":[true],
+      "use_accel_paired": [true],
+      "accel_paired_score_function": ["paired"],
+  
+      "checkpoint_basis":["student_grad_updates"],
+      "archive_interval": [5000],
+  
+      "lr": [1e-4],
+      "gamma": [0.995],
+      "entropy_coef": [0.005, 0.0],
+      "adv_entropy_coef": [0.05, 0.0],
+  
+      "recurrent_arch": ["lstm"],
+      "recurrent_agent": [true],
+      "recurrent_adversary_env": [false],
+      "recurrent_hidden_size": [256],
+  
+      "use_plr": [true],
+      "level_replay_prob": [0.8],
+      "level_replay_rho":[0.5],
+      "level_replay_seed_buffer_size":[4000],
+      "level_replay_temperature": [0.3],
+      "level_replay_strategy": ["positive_value_loss"],
+      "level_replay_score_transform": ["rank"],
+      "no_exploratory_grad_updates": [true],
+  
+      "use_editor": [true],
+      "level_editor_prob": [1.0],
+      "level_editor_method": ["random"],
+      "num_edits": [5],
+      "base_levels": ["easy"],
+
+      "use_behavioural_cloning": [true],
+        "kl_loss_coef": [0.01],
+        "kl_update_step": [10],
+		"use_kl_only_agent": [false, true],
+  
+      "test_env_names": ["MultiGrid-SixteenRooms-v0,MultiGrid-Maze-v0,MultiGrid-Labyrinth-v0"],
+
+      "log_dir": ["~/logs/accel"],
+      "log_interval": [25],
+      "log_action_complexity": [true],
+      "log_plr_buffer_stats": [true],
+      "log_replay_complexity": [true],
+      "reject_unsolvable_seeds": [false],
+      "screenshot_interval": [1000],
+  
+      "checkpoint": [true]
+    }
+  }

--- a/train_scripts/make_cmd.py
+++ b/train_scripts/make_cmd.py
@@ -171,6 +171,9 @@ def xpid_from_params(p, prefix=''):
     editing_prefix = ''
     if p['use_editor']:
         editing_prefix = f"-editor{p['level_editor_prob']}-{p['level_editor_method']}-n{p['num_edits']}-base{p['base_levels']}"
+    
+    if p['use_accel_paired']:
+        editing_prefix = f"{editing_prefix}-{p['accel_paired_score_function']}"
 
     timelimits = '-tl' if p['handle_timelimits'] else ''
     global_critic = '-global' if p['use_global_critic'] else ''
@@ -241,6 +244,9 @@ if __name__ == '__main__':
         'level_editor_method': 'random',
         'num_edits': 0,
         'base_levels': 'batch',
+        'use_accel_paired': False,
+        'accel_paired_score_function': 'paired',
+        'use_lstm': False,
         
         # Behavioural Cloning params
         'use_behavioural_cloning': False,


### PR DESCRIPTION
This PR adds support for Evo experiments in PAIRED for both environment types - Minigrid and BipedalWalker. After implementing the changes, we are still able to repro the underlying ACCEL's rollouts for 1-2 episodes.